### PR TITLE
"point" undefined error fixed: should be "p"

### DIFF
--- a/examples/patent_set_expansion.ipynb
+++ b/examples/patent_set_expansion.ipynb
@@ -475,7 +475,7 @@
         "  \"\"\"\n",
         "  return [\n",
         "      core_point for core_point in core_points_list\n",
-        "      if shared_nearest_neighbors[point][core_point] >= eps\n",
+        "      if shared_nearest_neighbors[p][core_point] >= eps\n",
         "  ]\n",
         "\n",
         "\n",


### PR DESCRIPTION
The find_core_neighbors function takes as an argument "p" but instead uses "point" inside the function. Changing from "point" to "p" fixes the error.